### PR TITLE
Refactor environment bootstrapping into reusable bash helper scripts

### DIFF
--- a/bootstrap/fetch-fs-open.sh
+++ b/bootstrap/fetch-fs-open.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+set -euo pipefail
+
+# Usage: ./fetch-fs-open.sh [target_dir]
+TARGET_DIR="${1:-fs-open}"
+FS_OPEN_URL="https://github.com/humbletim/firestorm-gha/releases/download/v7.2.3-vr-alpha-0/fs-open-80036-afc53db-afc53db-devtime.zip"
+
+if [ -d "$TARGET_DIR" ]; then
+    echo "[$0] fs-open already exists at $TARGET_DIR."
+    # To keep idempotency and prevent exit stopping the caller if sourced (though we execute it), we just return 0 here.
+    # Return 0 will cause bash to finish the script if not sourced, or return from function if sourced.
+    # Better yet, use a conditional block.
+else
+    echo "[$0] Fetching fs-open into $TARGET_DIR..."
+
+    TMP_ZIP=$(mktemp)
+    wget -nv "$FS_OPEN_URL" -O "$TMP_ZIP"
+
+    unzip -q "$TMP_ZIP"
+    if [ "$TARGET_DIR" != "fs-open" ]; then
+        mv fs-open "$TARGET_DIR"
+    fi
+
+    rm -f "$TMP_ZIP"
+
+    echo "[$0] fs-open successfully fetched to $TARGET_DIR."
+fi

--- a/bootstrap/fetch-winsdk.sh
+++ b/bootstrap/fetch-winsdk.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+set -euo pipefail
+
+# Usage: ./fetch-winsdk.sh [target_dir]
+TARGET_DIR="${1:-winsdk}"
+
+if [ -d "$TARGET_DIR" ] && [ -f "$TARGET_DIR/vfsoverlay.json" ]; then
+    echo "[$0] winsdk already exists at $TARGET_DIR."
+else
+    echo "[$0] Fetching winsdk into $TARGET_DIR..."
+
+    TMP_DIR=$(mktemp -d)
+    TMP_TGZ="$TMP_DIR/xwin.tar.gz"
+
+    wget -nv "https://github.com/Jake-Shadle/xwin/releases/download/0.8.0/xwin-0.8.0-x86_64-unknown-linux-musl.tar.gz" -O "$TMP_TGZ"
+
+    mkdir -p "$TMP_DIR/bin"
+    tar -C "$TMP_DIR/bin" --wildcards --strip-components=1 -xvf "$TMP_TGZ" '*/xwin'
+    chmod a+x "$TMP_DIR/bin/xwin"
+
+    SDKVER=10.0.26100
+    CRTVER=14.44.17.14
+    VARIANTS=desktop
+
+    mkdir -p "$TMP_DIR/cache"
+    "$TMP_DIR/bin/xwin" --accept-license -Loff --cache-dir="$TMP_DIR/cache" --variant "$VARIANTS" --crt-version "$CRTVER" --sdk-version "$SDKVER" splat --output "$TARGET_DIR"
+
+    touch "$TARGET_DIR/vfsoverlay.json"
+
+    rm -rf "$TMP_DIR"
+    echo "[$0] winsdk successfully fetched to $TARGET_DIR."
+fi

--- a/bootstrap/setup-llvm.sh
+++ b/bootstrap/setup-llvm.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+set -euo pipefail
+
+# Usage: ./setup-llvm.sh [target_dir]
+TARGET_DIR="${1:-llvm}"
+
+if [ -e "$TARGET_DIR" ] && [ -d "$TARGET_DIR" ]; then
+    echo "[$0] llvm already exists at $TARGET_DIR."
+else
+    echo "[$0] Setting up llvm at $TARGET_DIR..."
+
+    if [ -d "/usr/lib/llvm-19" ]; then
+        echo "[$0] Found LLVM 19 at /usr/lib/llvm-19."
+        ln -vsTf /usr/lib/llvm-19 "$TARGET_DIR"
+    elif [ -d "/opt/humbletim/llvm" ]; then
+        echo "[$0] Found LLVM 19 at /opt/humbletim/llvm."
+        ln -vsTf /opt/humbletim/llvm "$TARGET_DIR"
+    else
+        echo "[$0] Fetching standalone LLVM 19 since standard paths were not found..."
+
+        LLVM_VER="19.1.7"
+        LLVM_URL="https://github.com/llvm/llvm-project/releases/download/llvmorg-$LLVM_VER/clang+llvm-$LLVM_VER-x86_64-linux-gnu-ubuntu-22.04.tar.xz"
+
+        TMP_DIR=$(mktemp -d)
+        TMP_XZ="$TMP_DIR/llvm.tar.xz"
+
+        wget -nv "$LLVM_URL" -O "$TMP_XZ"
+
+        mkdir -p "$TMP_DIR/extracted"
+        tar -C "$TMP_DIR/extracted" --strip-components=1 -xf "$TMP_XZ"
+
+        mv "$TMP_DIR/extracted" "$TARGET_DIR"
+
+        rm -rf "$TMP_DIR"
+    fi
+
+    echo "[$0] llvm successfully set up at $TARGET_DIR."
+fi

--- a/build-edge.sh
+++ b/build-edge.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+set -euo pipefail
+
+# Main driver to compile modded fs-open.exe
+
+echo "==== Bootstrapping environment ===="
+./bootstrap/fetch-fs-open.sh fs-open
+./bootstrap/fetch-winsdk.sh winsdk
+./bootstrap/setup-llvm.sh llvm
+
+echo "==== Setting up symlinks ===="
+cd community
+ln -vsTf ../llvm llvm
+ln -vsTf ../winsdk winsdk
+touch winsdk/vfsoverlay.json
+
+echo "==== Initializing TPVM environment ===="
+../experiments/tpvm.sh init ../fs-open
+
+echo "==== Applying patches and fetching local code ===="
+# Use check logic before patching
+if [ ! -f llviewerdisplay.cpp ] || ! grep -q "vrmod_llviewerdisplay_begin_render" llviewerdisplay.cpp; then
+    rm -f llviewerdisplay.cpp
+    ../experiments/tpvm.sh patch llviewerdisplay.cpp
+else
+    echo "llviewerdisplay.cpp already patched."
+fi
+
+if [ ! -f lldir_win32.cpp ]; then
+    ../experiments/tpvm.sh mod lldir_win32.cpp
+else
+    echo "lldir_win32.cpp already modified."
+fi
+
+echo "==== Compiling Edge fs-open.exe ===="
+make fs-open.exe -j
+
+echo "==== Build Complete ===="
+ls -l fs-open.exe


### PR DESCRIPTION
Refactor environment bootstrapping into reusable shell helper scripts for `fs-open`, `winsdk`, and `llvm`. Replaced the previous monolithic ad-hoc script sequence with simpler, composable build steps, coordinated via a new `build-edge.sh` driver script.

---
*PR created automatically by Jules for task [5874414529730691386](https://jules.google.com/task/5874414529730691386) started by @humbletim*