### PR TITLE
Add optional environment variables to fix aspect ratio issues.

### DIFF
--- a/community/llviewerVR.cpp
+++ b/community/llviewerVR.cpp
@@ -700,7 +700,15 @@ void llviewerVR::vrStartup(bool is_shutdown)
 				gVRInitComplete = TRUE;
 				vr::VRCompositor()->SetTrackingSpace(vr::TrackingUniverseSeated);
 				gHMD->GetRecommendedRenderTargetSize(&m_nRenderWidth, &m_nRenderHeight);
-				
+
+				if (gVrModSettings->renderWidthOverride != 0
+					&& gVrModSettings->renderHeightOverride != 0
+					&& gVrModSettings->renderWidthOverride < 16384
+					&& gVrModSettings->renderHeightOverride < 16384) 
+				{
+					m_nRenderHeight=gVrModSettings->renderHeightOverride;
+					m_nRenderWidth=gVrModSettings->renderWidthOverride;
+				}
 				//m_nRenderHeight	=	1440;
 				//m_nRenderWidth	=	1440;
 				//if (leftEyeDesc.m_nResolveTextureId == NULL)
@@ -839,13 +847,24 @@ bool llviewerVR::ProcessVRCamera()
 			float mult = (float)m_nRenderWidth / (float)m_nRenderHeight;
 			if (m_nRenderHeight<m_nRenderWidth)
 			mult = (float)m_nRenderHeight / (float)m_nRenderWidth;
-			
+
 			m_ScrSize.mX = (scrsize*mult)*0.95;
 			m_ScrSize.mY = (scrsize)*0.95;
-			if (m_ScrSizeOld.mX != m_ScrSize.mX || m_ScrSizeOld.mY != m_ScrSize.mY)
+			if (gVrModSettings->windowWidthOverride != 0 
+				&& gVrModSettings->windowHeightOverride != 0 
+				&& gVrModSettings->windowWidthOverride < 16384
+				&& gVrModSettings->windowHeightOverride < 16384) 
 			{
-				m_ScrSize.set(m_ScrSize.mX, m_ScrSize.mY);
-				WI->setSize(m_ScrSize);
+				m_ScrSize.mX=gVrModSettings->windowWidthOverride;
+				m_ScrSize.mY=gVrModSettings->windowHeightOverride;
+			}	
+			if (gVrModSettings->resizeWindow) 
+			{
+				if (m_ScrSizeOld.mX != m_ScrSize.mX || m_ScrSizeOld.mY != m_ScrSize.mY)
+				{
+					m_ScrSize.set(m_ScrSize.mX, m_ScrSize.mY);
+					WI->setSize(m_ScrSize);
+				}
 			}
 			//Constrain the cursor to the viewer window.
 			if (m_MousePos.mX >= m_ScrSize.mX)

--- a/community/llviewerVR.vrmod_settings.c++
+++ b/community/llviewerVR.vrmod_settings.c++
@@ -80,7 +80,19 @@ struct VrModSettings {
         "0.001 is a good value to try using; 0.015 is a good compromise to avoid z-fighting.\n"
         "Note: When VR Mode is active, this setting can be changed live to test the effect of different near clipping thresholds."
     };
-
+    LLCachedControl<U32>  windowWidthOverride{ gSavedSettings, "vrmod.windowWidthOverride", DEFAULTS.at("windowWidthOverride").to_number<U32>(),
+        "Set to > 0 to override window Width"
+    };
+    LLCachedControl<U32>  windowHeightOverride{ gSavedSettings, "vrmod.windowHeightOverride", DEFAULTS.at("windowHeightOverride").to_number<U32>(),
+        "Set to > 0 to override window Height"
+    };
+    LLCachedControl<U32>  renderWidthOverride{ gSavedSettings, "vrmod.renderWidthOverride", DEFAULTS.at("renderWidthOverride").to_number<U32>(),
+        "Set to > 0 to override render Width"
+    };
+    LLCachedControl<U32>  renderHeightOverride{ gSavedSettings, "vrmod.renderHeightOverride", DEFAULTS.at("renderHeightOverride").to_number<U32>(),
+        "Set to > 0 to override render Height"
+    };   
+    LLCachedControl<bool> resizeWindow{ gSavedSettings, "vrmod.resizeWindow", DEFAULTS.at("resizeWindow").as_bool(), "Resize window and switch to windowed mode for VR(set to false if using overrides and full screen mode)" }; 
     // Updates a single property within the persisted JSON blob.
     void updateJsonEntry(std::string const& key, LLSD const& newValue);
 
@@ -98,6 +110,11 @@ struct VrModSettings {
     { "mousecursor",     true },
     { "cameraAngle",     0.0f },
     { "nearClip",        0.0f },
+    { "windowWidthOverride", 0},
+    { "windowHeightOverride",0},
+    { "renderWidthOverride", 0},
+    { "renderHeightOverride",0},
+    { "resizeWindow",     true}
 };
 
 namespace {

--- a/p373r/llviewerVR.cpp
+++ b/p373r/llviewerVR.cpp
@@ -644,6 +644,15 @@ void llviewerVR::vrStartup(bool is_shutdown)
 				
 				//m_nRenderHeight	=	1440;
 				//m_nRenderWidth	=	1440;
+
+				// using environment variables so settings can be changed if the resolution is set incorrectly and the UI doesn't work
+				// optional overrides for render target size if environment variables are set
+				if (getenv("FSVRRenderHeight") && getenv("FSVRRenderWidth")) 
+				{
+					m_nRenderHeight=atoi(getenv("FSVRRenderHeight"));
+					m_nRenderWidth=atoi(getenv("FSVRRenderWidth"));
+				}
+				
 				//if (leftEyeDesc.m_nResolveTextureId == NULL)
 				CreateFrameBuffer(m_nRenderWidth, m_nRenderHeight, leftEyeDesc);
 				//if (rightEyeDesc.m_nResolveTextureId == NULL)
@@ -746,14 +755,30 @@ bool llviewerVR::ProcessVRCamera()
 			float mult = (float)m_nRenderWidth / (float)m_nRenderHeight;
 			if (m_nRenderHeight<m_nRenderWidth)
 			mult = (float)m_nRenderHeight / (float)m_nRenderWidth;
-			
-			m_ScrSize.mX = (scrsize*mult)*0.95;
-			m_ScrSize.mY = (scrsize)*0.95;
-			if (m_ScrSizeOld.mX != m_ScrSize.mX || m_ScrSizeOld.mY != m_ScrSize.mY)
+		
+			// using environment variables so settings can be changed if the resolution is set incorrectly and the UI doesn't work
+			// optional overrides for screen size if environment variables are set
+			if (getenv("FSVRScreenHeight") && getenv("FSVRScreenWidth")) 
 			{
-				m_ScrSize.set(m_ScrSize.mX, m_ScrSize.mY);
-				WI->setSize(m_ScrSize);
+				m_ScrSize.mX = atoi(getenv("FSVRScreenWidth"))*1.0;
+				m_ScrSize.mY = atoi(getenv("FSVRScreenHeight"))*1.0;
+			} 
+			else 
+			{
+				m_ScrSize.mX = (scrsize*mult)*0.95;
+				m_ScrSize.mY = (scrsize)*0.95;
 			}
+
+			// optional override to prevent switch between fullscreen and windowed
+			if (!getenv("FSVRNoResize")) 
+			{
+				if (m_ScrSizeOld.mX != m_ScrSize.mX || m_ScrSizeOld.mY != m_ScrSize.mY)
+				{
+					m_ScrSize.set(m_ScrSize.mX, m_ScrSize.mY);
+					WI->setSize(m_ScrSize);
+				}
+			}
+
 			//Constrain the cursor to the viewer window.
 			if (m_MousePos.mX >= m_ScrSize.mX)
 				m_MousePos.mX = m_ScrSize.mX - 1;


### PR DESCRIPTION
I'm still figuring out how to build the viewer so I'm marking this pull request as draft for review until I can get the build working or someone else can.  I did some assembly language patching by hand with the original executable to verify that changing the variable values fixed the fullscreen UI switching to windowed mode and taking up half of the non-VR desktop instead of the full screen.